### PR TITLE
Fixed a small typo in conversion_tools/usage/MovieLens.md

### DIFF
--- a/conversion_tools/usage/MovieLens.md
+++ b/conversion_tools/usage/MovieLens.md
@@ -61,9 +61,9 @@ python run.py --dataset ml-20m \
 
 `output_path` is the path to store converted atomic files
 
- `convert_inter` ml-100k, ml-1m, ml-10m and ml-10m all can be converted to '*.item' atomic file
+`convert_inter` ml-100k, ml-1m, ml-10m and ml-10m all can be converted to '*.inter' atomic file
 
- `convert_item` ml-100k, ml-1m, ml-10m and ml-10m can be converted to '*.inter' atomic file
+`convert_item` ml-100k, ml-1m, ml-10m and ml-10m can be converted to '*.item' atomic file
 
 `convert_user` ml-100k, ml-1m can be converted to '*.user' atomic file
 


### PR DESCRIPTION
Fixed a small typo in conversion_tools/usage/MovieLens.md.

`convert_inter` ml-100k, ml-1m, ml-10m and ml-10m all can be converted to **'*.item'** atomic file -> _'*.inter'_ 

`convert_item` ml-100k, ml-1m, ml-10m and ml-10m can be converted to **'*.inter'** atomic file -> _'*.item'_ 