### PR TITLE
Include Music4All-Onion in the datasets

### DIFF
--- a/conversion_tools/src/extended_dataset.py
+++ b/conversion_tools/src/extended_dataset.py
@@ -15,6 +15,54 @@ from src.base_dataset import BaseDataset
 from src.cosmetics import CosmeticsDataset
 
 
+class Music4AllOnion(BaseDataset):
+    def __init__(self, input_path, output_path, interaction_type):
+        super(Music4AllOnion, self).__init__(input_path, output_path)
+        self.dataset_name = 'onion'
+        self.sep = '\t'
+
+        # output_file
+        _, self.output_item_file, self.output_user_file = self.get_output_files()
+
+        self.interaction_type = interaction_type
+
+        # input file
+        if self.interaction_type == 'counts':
+            self.inter_file = os.path.join(self.input_path, 'userid_trackid_count.tsv')
+            # selected feature fields
+            self.inter_fields = {0: 'user_id:token',
+                                 1: 'track_id:token',
+                                 2: 'count:token',
+                                 }
+            self.output_inter_file = os.path.join(self.output_path, self.dataset_name + '_counts.inter')
+        elif self.interaction_type == 'timestamp':
+            self.inter_file = os.path.join(self.input_path, 'userid_trackid_timestamp.tsv')
+            # selected feature fields
+            self.inter_fields = {0: 'user_id:token',
+                                 1: 'track_id:token',
+                                 2: 'timestamp:token',
+                                 }
+            self.output_inter_file = os.path.join(self.output_path, self.dataset_name + '_timestamp.inter')
+
+    def convert_inter(self):
+        fout = open(self.output_inter_file, 'w')
+        fout.write('\t'.join([self.inter_fields[i] for i in range(len(self.inter_fields))]) + '\n')
+
+        with open(self.inter_file, 'r') as f:
+            line = f.readline()
+            while True:
+                if not line:
+                    break
+
+                line = line.strip().split('\t')
+                userid, itemid, count = line[0], line[1], line[2]
+                fout.write(str(userid) + '\t' + str(itemid) + '\t' + str(count) + '\n')
+                line = f.readline()
+
+        print(self.output_inter_file + ' is done!')
+        fout.close()
+
+
 class ML100KDataset(BaseDataset):
     def __init__(self, input_path, output_path):
         super(ML100KDataset, self).__init__(input_path, output_path)
@@ -479,7 +527,7 @@ class CRITEODataset(BaseDataset):
         fout = open(self.output_file, "w")
         fout.write('\t'.join([self.fields.get(i) for i in self.fields.keys()]) + '\n')
 
-        # Get file rows 
+        # Get file rows
         lines_count = 0
         for _ in fin:
             lines_count += 1
@@ -663,7 +711,7 @@ class DIGINETICADataset(BaseDataset):
         fout_prod = open(self.output_file_prod, "w")
         fout_prod.write('\t'.join([self.fields_item.get(i) for i in self.fields_item.keys()]) + '\n')
 
-        # Get file rows 
+        # Get file rows
         lines_count = 0
         for _ in fin:
             lines_count += 1
@@ -4841,31 +4889,31 @@ class MINDLargeTrainDataset(BaseDataset):
         self.sep = '\t'
 
         # input file
-        self.item_file = os.path.join(self.input_path, 'news.tsv').replace('\\','/')
-        self.inter_file = os.path.join(self.input_path, 'behaviors.tsv').replace('\\','/')
-        
+        self.item_file = os.path.join(self.input_path, 'news.tsv').replace('\\', '/')
+        self.inter_file = os.path.join(self.input_path, 'behaviors.tsv').replace('\\', '/')
+
         # output file
-        self.output_item_file = os.path.join(self.output_path, 'mind_large_train.item').replace('\\','/')
-        self.output_inter_file = os.path.join(self.output_path, 'mind_large_train.inter').replace('\\','/')
-        
+        self.output_item_file = os.path.join(self.output_path, 'mind_large_train.item').replace('\\', '/')
+        self.output_inter_file = os.path.join(self.output_path, 'mind_large_train.inter').replace('\\', '/')
+
         # fields
         self.item_fields = {
-                             0: 'item_id:token',
-                             1: 'category:token_seq',
-                             2: 'sub_category:token_seq',
-                             3: 'title:token_seq',
-                             4: 'abstract:token_seq',
-                             5: 'url:token_seq',
-                             6: 'title_entities:token_seq',
-                             7: 'abstract_entities:token_seq'
-                             }
+            0: 'item_id:token',
+            1: 'category:token_seq',
+            2: 'sub_category:token_seq',
+            3: 'title:token_seq',
+            4: 'abstract:token_seq',
+            5: 'url:token_seq',
+            6: 'title_entities:token_seq',
+            7: 'abstract_entities:token_seq'
+        }
         self.inter_fields = {
-                             0: 'user_id:token',
-                             1: 'item_id:token',
-                             2: 'label:float',
-                             3: 'timestamp:float'
-                             }
-    
+            0: 'user_id:token',
+            1: 'item_id:token',
+            2: 'label:float',
+            3: 'timestamp:float'
+        }
+
     def convert_item(self):
         fin = open(self.item_file, 'r')
         fout = open(self.output_item_file, "w")
@@ -4897,7 +4945,7 @@ class MINDLargeTrainDataset(BaseDataset):
 
         fout.write('\t'.join([self.inter_fields[column] for column in self.inter_fields.keys()]) + '\n')
 
-        current_list = [0,0,0,0]
+        current_list = [0, 0, 0, 0]
         for i in tqdm(range(lines_count)):
             line = fin.readline()
             line_list = line.split('\t')
@@ -4912,7 +4960,7 @@ class MINDLargeTrainDataset(BaseDataset):
                 item, rating = rate.split('-')
                 item = item.strip('N')
 
-                fout.write('\t'.join([current_list[0], item, rating, timestamp ])+'\n')
+                fout.write('\t'.join([current_list[0], item, rating, timestamp]) + '\n')
         fin.close()
         fout.close()
 
@@ -4927,7 +4975,7 @@ class MINDLargeTrainDataset(BaseDataset):
 
         fout.write('\t'.join([self.inter_fields[column] for column in self.inter_fields.keys()]) + '\n')
 
-        current_list = [0,0,0,0]
+        current_list = [0, 0, 0, 0]
         for i in tqdm(range(lines_count)):
             line = fin.readline()
             line_list = line.split('\t')
@@ -4942,9 +4990,10 @@ class MINDLargeTrainDataset(BaseDataset):
                 item, rating = rate.split('-')
                 item = item.strip('N')
 
-                fout.write('\t'.join([current_list[0], item, rating, timestamp ])+'\n')
+                fout.write('\t'.join([current_list[0], item, rating, timestamp]) + '\n')
         fin.close()
         fout.close()
+
 
 class MINDLargeDevDataset(BaseDataset):
     def __init__(self, input_path, output_path):
@@ -4953,31 +5002,31 @@ class MINDLargeDevDataset(BaseDataset):
         self.sep = '\t'
 
         # input file
-        self.item_file = os.path.join(self.input_path, 'news.tsv').replace('\\','/')
-        self.inter_file = os.path.join(self.input_path, 'behaviors.tsv').replace('\\','/')
-        
+        self.item_file = os.path.join(self.input_path, 'news.tsv').replace('\\', '/')
+        self.inter_file = os.path.join(self.input_path, 'behaviors.tsv').replace('\\', '/')
+
         # output file
-        self.output_item_file = os.path.join(self.output_path, 'mind_large_dev.item').replace('\\','/')
-        self.output_inter_file = os.path.join(self.output_path, 'mind_large_dev.inter').replace('\\','/')
-        
+        self.output_item_file = os.path.join(self.output_path, 'mind_large_dev.item').replace('\\', '/')
+        self.output_inter_file = os.path.join(self.output_path, 'mind_large_dev.inter').replace('\\', '/')
+
         # fields
         self.item_fields = {
-                             0: 'item_id:token',
-                             1: 'category:token_seq',
-                             2: 'sub_category:token_seq',
-                             3: 'title:token_seq',
-                             4: 'abstract:token_seq',
-                             5: 'url:token_seq',
-                             6: 'title_entities:token_seq',
-                             7: 'abstract_entities:token_seq'
-                             }
+            0: 'item_id:token',
+            1: 'category:token_seq',
+            2: 'sub_category:token_seq',
+            3: 'title:token_seq',
+            4: 'abstract:token_seq',
+            5: 'url:token_seq',
+            6: 'title_entities:token_seq',
+            7: 'abstract_entities:token_seq'
+        }
         self.inter_fields = {
-                             0: 'user_id:token',
-                             1: 'item_id:token',
-                             2: 'label:float',
-                             3: 'timestamp:float'
-                             }
-    
+            0: 'user_id:token',
+            1: 'item_id:token',
+            2: 'label:float',
+            3: 'timestamp:float'
+        }
+
     def convert_item(self):
         fin = open(self.item_file, 'r')
         fout = open(self.output_item_file, "w")
@@ -5009,7 +5058,7 @@ class MINDLargeDevDataset(BaseDataset):
 
         fout.write('\t'.join([self.inter_fields[column] for column in self.inter_fields.keys()]) + '\n')
 
-        current_list = [0,0,0,0]
+        current_list = [0, 0, 0, 0]
         for i in tqdm(range(lines_count)):
             line = fin.readline()
             line_list = line.split('\t')
@@ -5024,9 +5073,10 @@ class MINDLargeDevDataset(BaseDataset):
                 item, rating = rate.split('-')
                 item = item.strip('N')
 
-                fout.write('\t'.join([current_list[0], item, rating, timestamp ])+'\n')
+                fout.write('\t'.join([current_list[0], item, rating, timestamp]) + '\n')
         fin.close()
         fout.close()
+
 
 class MINDSmallTrainDataset(BaseDataset):
     def __init__(self, input_path, output_path):
@@ -5035,31 +5085,31 @@ class MINDSmallTrainDataset(BaseDataset):
         self.sep = '\t'
 
         # input file
-        self.item_file = os.path.join(self.input_path, 'news.tsv').replace('\\','/')
-        self.inter_file = os.path.join(self.input_path, 'behaviors.tsv').replace('\\','/')
-        
+        self.item_file = os.path.join(self.input_path, 'news.tsv').replace('\\', '/')
+        self.inter_file = os.path.join(self.input_path, 'behaviors.tsv').replace('\\', '/')
+
         # output file
-        self.output_item_file = os.path.join(self.output_path, 'mind_small_train.item').replace('\\','/')
-        self.output_inter_file = os.path.join(self.output_path, 'mind_small_train.inter').replace('\\','/')
-        
+        self.output_item_file = os.path.join(self.output_path, 'mind_small_train.item').replace('\\', '/')
+        self.output_inter_file = os.path.join(self.output_path, 'mind_small_train.inter').replace('\\', '/')
+
         # fields
         self.item_fields = {
-                             0: 'item_id:token',
-                             1: 'category:token_seq',
-                             2: 'sub_category:token_seq',
-                             3: 'title:token_seq',
-                             4: 'abstract:token_seq',
-                             5: 'url:token_seq',
-                             6: 'title_entities:token_seq',
-                             7: 'abstract_entities:token_seq'
-                             }
+            0: 'item_id:token',
+            1: 'category:token_seq',
+            2: 'sub_category:token_seq',
+            3: 'title:token_seq',
+            4: 'abstract:token_seq',
+            5: 'url:token_seq',
+            6: 'title_entities:token_seq',
+            7: 'abstract_entities:token_seq'
+        }
         self.inter_fields = {
-                             0: 'user_id:token',
-                             1: 'item_id:token',
-                             2: 'label:float',
-                             3: 'timestamp:float'
-                             }
-    
+            0: 'user_id:token',
+            1: 'item_id:token',
+            2: 'label:float',
+            3: 'timestamp:float'
+        }
+
     def convert_item(self):
         fin = open(self.item_file, 'r')
         fout = open(self.output_item_file, "w")
@@ -5091,7 +5141,7 @@ class MINDSmallTrainDataset(BaseDataset):
 
         fout.write('\t'.join([self.inter_fields[column] for column in self.inter_fields.keys()]) + '\n')
 
-        current_list = [0,0,0,0]
+        current_list = [0, 0, 0, 0]
         for i in tqdm(range(lines_count)):
             line = fin.readline()
             line_list = line.split('\t')
@@ -5106,42 +5156,43 @@ class MINDSmallTrainDataset(BaseDataset):
                 item, rating = rate.split('-')
                 item = item.strip('N')
 
-                fout.write('\t'.join([current_list[0], item, rating, timestamp ])+'\n')
+                fout.write('\t'.join([current_list[0], item, rating, timestamp]) + '\n')
         fin.close()
         fout.close()
+
 
 class MINDSmallDevDataset(BaseDataset):
     def __init__(self, input_path, output_path):
         super(MINDSmallDevDataset, self).__init__(input_path, output_path)
         self.dataset_name = 'mind_small_dev'
         self.sep = '\t'
-        
+
         # input file
-        self.item_file = os.path.join(self.input_path, 'news.tsv').replace('\\','/')
-        self.inter_file = os.path.join(self.input_path, 'behaviors.tsv').replace('\\','/')
-        
+        self.item_file = os.path.join(self.input_path, 'news.tsv').replace('\\', '/')
+        self.inter_file = os.path.join(self.input_path, 'behaviors.tsv').replace('\\', '/')
+
         # output file
-        self.output_item_file = os.path.join(self.output_path, 'mind_small_dev.item').replace('\\','/')
-        self.output_inter_file = os.path.join(self.output_path, 'mind_small_dev.inter').replace('\\','/')
-        
+        self.output_item_file = os.path.join(self.output_path, 'mind_small_dev.item').replace('\\', '/')
+        self.output_inter_file = os.path.join(self.output_path, 'mind_small_dev.inter').replace('\\', '/')
+
         # fields
         self.item_fields = {
-                             0: 'item_id:token',
-                             1: 'category:token_seq',
-                             2: 'sub_category:token_seq',
-                             3: 'title:token_seq',
-                             4: 'abstract:token_seq',
-                             5: 'url:token_seq',
-                             6: 'title_entities:token_seq',
-                             7: 'abstract_entities:token_seq'
-                             }
+            0: 'item_id:token',
+            1: 'category:token_seq',
+            2: 'sub_category:token_seq',
+            3: 'title:token_seq',
+            4: 'abstract:token_seq',
+            5: 'url:token_seq',
+            6: 'title_entities:token_seq',
+            7: 'abstract_entities:token_seq'
+        }
         self.inter_fields = {
-                             0: 'user_id:token',
-                             1: 'item_id:token',
-                             2: 'label:float',
-                             3: 'timestamp:float'
-                             }
-    
+            0: 'user_id:token',
+            1: 'item_id:token',
+            2: 'label:float',
+            3: 'timestamp:float'
+        }
+
     def convert_item(self):
         fin = open(self.item_file, 'r')
         fout = open(self.output_item_file, "w")
@@ -5173,7 +5224,7 @@ class MINDSmallDevDataset(BaseDataset):
 
         fout.write('\t'.join([self.inter_fields[column] for column in self.inter_fields.keys()]) + '\n')
 
-        current_list = [0,0,0,0]
+        current_list = [0, 0, 0, 0]
         for i in tqdm(range(lines_count)):
             line = fin.readline()
             line_list = line.split('\t')
@@ -5188,6 +5239,6 @@ class MINDSmallDevDataset(BaseDataset):
                 item, rating = rate.split('-')
                 item = item.strip('N')
 
-                fout.write('\t'.join([current_list[0], item, rating, timestamp ])+'\n')
+                fout.write('\t'.join([current_list[0], item, rating, timestamp]) + '\n')
         fin.close()
         fout.close()

--- a/conversion_tools/src/utils.py
+++ b/conversion_tools/src/utils.py
@@ -4,6 +4,7 @@
 
 
 dataset2class = {
+    'onion': 'Music4AllOnion',
     'ml-100k': 'ML100KDataset',
     'ml-1m': 'ML1MDataset',
     'ml-10m': 'ML10MDataset',
@@ -79,6 +80,7 @@ click_dataset = {
 }
 
 multiple_dataset = {
+    'Music4AllOnion',
     'YOOCHOOSEDataset',
     'RETAILROCKETDataset',
     'TAFENGDataset',


### PR DESCRIPTION
Hi! 

I modified the code to include a class for the dataset [Music4All-Onion](https://dl.acm.org/doi/10.1145/3511808.3557656). So far, only the .inter file gets converted. One remark: for the file with the timestamp, I selected `token` as format, since the timestamp is given as date and time, for instance `2013-01-27 21:42:38`. Maybe there is a better way?

There are a couple of ToDo's:
 - Include code for `.item` and `.user` files
 - Include a README with instructions on how to download the dataset and convert it
 - Upload the converted atomic files to your collection of files
 
 I will work on the `.item` part in the next days.

Thank you for this great library! 
Cheers
Marta
